### PR TITLE
Fix CRD contract version label

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,6 +1,5 @@
 commonLabels:
-  cluster.x-k8s.io/v1beta1: v1beta3
-  cluster.x-k8s.io/v1beta2: v1beta3
+  cluster.x-k8s.io/v1beta1: v1beta1_v1beta2_v1beta3
 
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes the CRD contract version label that was incorrectly defined, since there is no CAPI API v1beta2 yet.

It also makes sure automatic conversions between the CAPC api versions can take place.

Reference: https://release-0-3.cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#apply-the-contract-version-label-clusterx-k8sioversion-version1_version2_version3-to-your-crds


*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->