### PR TITLE
Implement Non-Strict Affinity and Anti-Affinity in CloudstackAffinityGroups

### DIFF
--- a/api/v1beta1/cloudstackaffinitygroup_types.go
+++ b/api/v1beta1/cloudstackaffinitygroup_types.go
@@ -27,7 +27,7 @@ const (
 // CloudStackAffinityGroupSpec defines the desired state of CloudStackAffinityGroup
 type CloudStackAffinityGroupSpec struct {
 	// Mutually exclusive parameter with AffinityGroupIDs.
-	// Can be "host affinity" or "host anti-affinity". Will create an affinity group per machine set.
+	// Can be "host affinity", "host anti-affinity", "non-strict host affinity"or "non-strict host anti-affinity". Will create an affinity group per machine set.
 	Type string `json:"type,omitempty"`
 
 	// Name.

--- a/api/v1beta1/cloudstackmachine_types.go
+++ b/api/v1beta1/cloudstackmachine_types.go
@@ -28,6 +28,8 @@ const (
 	MachineFinalizer = "cloudstackmachine.infrastructure.cluster.x-k8s.io"
 	ProAffinity      = "pro"
 	AntiAffinity     = "anti"
+	SoftProAffinity  = "soft-pro"
+	SoftAntiAffinity = "soft-anti"
 	NoAffinity       = "no"
 )
 

--- a/api/v1beta2/cloudstackmachine_types.go
+++ b/api/v1beta2/cloudstackmachine_types.go
@@ -27,9 +27,11 @@ import (
 const MachineFinalizer = "cloudstackmachine.infrastructure.cluster.x-k8s.io"
 
 const (
-	ProAffinity  = "pro"
-	AntiAffinity = "anti"
-	NoAffinity   = "no"
+	ProAffinity      = "pro"
+	AntiAffinity     = "anti"
+	SoftProAffinity  = "soft-pro"
+	SoftAntiAffinity = "soft-anti"
+	NoAffinity       = "no"
 )
 
 // CloudStackMachineSpec defines the desired state of CloudStackMachine

--- a/api/v1beta3/cloudstackaffinitygroup_types.go
+++ b/api/v1beta3/cloudstackaffinitygroup_types.go
@@ -25,7 +25,7 @@ const AffinityGroupFinalizer = "affinitygroup.infrastructure.cluster.x-k8s.io"
 // CloudStackAffinityGroupSpec defines the desired state of CloudStackAffinityGroup
 type CloudStackAffinityGroupSpec struct {
 	// Mutually exclusive parameter with AffinityGroupIDs.
-	// Can be "host affinity" or "host anti-affinity". Will create an affinity group per machine set.
+	// Can be "host affinity", "host anti-affinity", "non-strict host affinity" or "non-strict host anti-affinity". Will create an affinity group per machine set.
 	Type string `json:"type,omitempty"`
 
 	// Name.

--- a/api/v1beta3/cloudstackmachine_types.go
+++ b/api/v1beta3/cloudstackmachine_types.go
@@ -27,9 +27,11 @@ import (
 const MachineFinalizer = "cloudstackmachine.infrastructure.cluster.x-k8s.io"
 
 const (
-	ProAffinity  = "pro"
-	AntiAffinity = "anti"
-	NoAffinity   = "no"
+	ProAffinity      = "pro"
+	AntiAffinity     = "anti"
+	SoftProAffinity  = "soft-pro"
+	SoftAntiAffinity = "soft-anti"
+	NoAffinity       = "no"
 )
 
 // CloudStackMachineSpec defines the desired state of CloudStackMachine

--- a/api/v1beta3/cloudstackmachinetemplate_webhook.go
+++ b/api/v1beta3/cloudstackmachinetemplate_webhook.go
@@ -64,9 +64,9 @@ func (r *CloudStackMachineTemplate) ValidateCreate() (admission.Warnings, error)
 	spec := r.Spec.Template.Spec
 
 	affinity := strings.ToLower(spec.Affinity)
-	if !(affinity == "" || affinity == "no" || affinity == "pro" || affinity == "anti") {
+	if !(affinity == "" || affinity == "no" || affinity == "pro" || affinity == "anti" || affinity == "soft-pro" || affinity == "soft-anti") {
 		errorList = append(errorList, field.Invalid(field.NewPath("spec", "Affinity"), spec.Affinity,
-			`Affinity must be "no", "pro", "anti", or unspecified.`))
+			`Affinity must be "no", "pro", "anti", "soft-pro", "soft-anti", or unspecified.`))
 	}
 	if affinity != "no" && affinity != "" && len(spec.AffinityGroupIDs) > 0 {
 		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "AffinityGroupIDs"),

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_cloudstackaffinitygroups.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_cloudstackaffinitygroups.yaml
@@ -44,8 +44,9 @@ spec:
                 type: string
               type:
                 description: Mutually exclusive parameter with AffinityGroupIDs. Can
-                  be "host affinity" or "host anti-affinity". Will create an affinity
-                  group per machine set.
+                  be "host affinity", "host anti-affinity", "non-strict host affinity"or
+                  "non-strict host anti-affinity". Will create an affinity group per
+                  machine set.
                 type: string
             type: object
           status:
@@ -150,8 +151,9 @@ spec:
                 type: string
               type:
                 description: Mutually exclusive parameter with AffinityGroupIDs. Can
-                  be "host affinity" or "host anti-affinity". Will create an affinity
-                  group per machine set.
+                  be "host affinity", "host anti-affinity", "non-strict host affinity"
+                  or "non-strict host anti-affinity". Will create an affinity group
+                  per machine set.
                 type: string
             type: object
           status:

--- a/controllers/utils/affinity_group.go
+++ b/controllers/utils/affinity_group.go
@@ -55,6 +55,10 @@ func (r *ReconciliationRunner) GetOrCreateAffinityGroup(
 			ag.Spec.Type = "host affinity"
 		} else if affinityType == infrav1.AntiAffinity {
 			ag.Spec.Type = "host anti-affinity"
+		} else if affinityType == infrav1.SoftProAffinity {
+			ag.Spec.Type = "non-strict host affinity"
+		} else if affinityType == infrav1.SoftAntiAffinity {
+			ag.Spec.Type = "non-strict host anti-affinity"
 		} else {
 			return ctrl.Result{}, errors.Errorf("unrecognized affinity type %s", affinityType)
 		}

--- a/pkg/cloud/affinity_groups.go
+++ b/pkg/cloud/affinity_groups.go
@@ -22,8 +22,10 @@ import (
 )
 
 const (
-	AntiAffinityGroupType = "host anti-affinity"
-	AffinityGroupType     = "host affinity"
+	AntiAffinityGroupType     = "host anti-affinity"
+	AffinityGroupType         = "host affinity"
+	SoftAntiAffinityGroupType = "non-strict anti-affinity"
+	SoftAffinityGroupType     = "non-strict host affinity"
 )
 
 type AffinityGroup struct {

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -150,6 +150,8 @@ E2E Test Run Logs: https://github.com/blueorangutan/capc-prs/releases/download/c
 [PASS] When testing with disk offering Should successfully create a cluster with disk offering
 [PASS] When testing affinity group Should have host affinity group when affinity is pro
 [PASS] When testing affinity group Should have host affinity group when affinity is anti
+[PASS] When testing affinity group Should have host affinity group when affinity is soft-pro
+[PASS] When testing affinity group Should have host affinity group when affinity is soft-anti
 [PASS] When the specified resource does not exist Should fail due to the specified account is not found [TC4a]
 [PASS] When the specified resource does not exist Should fail due to the specified domain is not found [TC4b]
 [PASS] When the specified resource does not exist Should fail due to the specified control plane offering is not found [TC7]

--- a/test/e2e/affinity_group.go
+++ b/test/e2e/affinity_group.go
@@ -73,6 +73,14 @@ func AffinityGroupSpec(ctx context.Context, inputGetter func() CommonSpecInput) 
 		affinityIds = executeTest(ctx, input, namespace, specName, clusterResources, "anti")
 	})
 
+	It("Should have host affinity group when affinity is soft-pro", func() {
+		affinityIds = executeTest(ctx, input, namespace, specName, clusterResources, "soft-pro")
+	})
+
+	It("Should have host affinity group when affinity is soft-anti", func() {
+		affinityIds = executeTest(ctx, input, namespace, specName, clusterResources, "soft-anti")
+	})
+
 	AfterEach(func() {
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
 		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -347,6 +347,12 @@ func CheckAffinityGroup(client *cloudstack.CloudStackClient, clusterName string,
 				if affinityType == "anti" && affinity.Type != "host anti-affinity" {
 					Fail(affinity.Type + " does not match " + affinityType)
 				}
+				if affinityType == "soft-pro" && affinity.Type != "non-strict host affinity" {
+					Fail(affinity.Type + " does not match " + affinityType)
+				}
+				if affinityType == "soft-anti" && affinity.Type != "non-strict host anti-affinity" {
+					Fail(affinity.Type + " does not match " + affinityType)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Description of changes:**

This PR introduces the use of soft affinity for nodes in CloudstackAffinityGroups. It leverages the non-strict Anti-affinity and non-strict Affinity features available in the latest version of CloudStack to enhance the deployment and management of resources.

