### PR TITLE
fix: CRD migration use status for storage version migration

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -89,7 +89,6 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - cloudstackaffinitygroups/status
-  - cloudstackclustertemplates/status
   - cloudstackisolatednetworks/status
   - cloudstackmachines/status
   - cloudstackmachinestatecheckers/status

--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func initFlags(fs *pflag.FlagSet) {
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackclusters;cloudstackmachines;cloudstackmachinetemplates;cloudstackclustertemplates;cloudstackfailuredomains;cloudstackisolatednetworks;cloudstackaffinitygroups;cloudstackmachinestatecheckers,verbs=get;list;watch;patch;update
-// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackclusters/status;cloudstackmachines/status;cloudstackmachinetemplates/status;cloudstackclustertemplates/status;cloudstackfailuredomains/status;cloudstackisolatednetworks/status;cloudstackaffinitygroups/status;cloudstackmachinestatecheckers/status,verbs=get;patch;update
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackclusters/status;cloudstackmachines/status;cloudstackmachinetemplates/status;cloudstackfailuredomains/status;cloudstackisolatednetworks/status;cloudstackaffinitygroups/status;cloudstackmachinestatecheckers/status,verbs=get;patch;update
 
 func main() {
 	initFlags(pflag.CommandLine)

--- a/main.go
+++ b/main.go
@@ -323,28 +323,36 @@ func setupReconcilers(ctx context.Context, mgr manager.Manager) {
 
 	crdMigratorConfig := map[client.Object]crdmigrator.ByObjectConfig{
 		&infrav1.CloudStackCluster{}: {
-			UseCache: true,
+			UseCache:                            true,
+			UseStatusForStorageVersionMigration: true,
 		},
 		&infrav1.CloudStackMachine{}: {
-			UseCache: true,
+			UseCache:                            true,
+			UseStatusForStorageVersionMigration: true,
 		},
 		&infrav1.CloudStackMachineTemplate{}: {
-			UseCache: true,
+			UseCache:                            true,
+			UseStatusForStorageVersionMigration: true,
 		},
 		&infrav1.CloudStackClusterTemplate{}: {
-			UseCache: true,
+			UseCache:                            true,
+			UseStatusForStorageVersionMigration: false,
 		},
 		&infrav1.CloudStackFailureDomain{}: {
-			UseCache: true,
+			UseCache:                            true,
+			UseStatusForStorageVersionMigration: true,
 		},
 		&infrav1.CloudStackIsolatedNetwork{}: {
-			UseCache: true,
+			UseCache:                            true,
+			UseStatusForStorageVersionMigration: true,
 		},
 		&infrav1.CloudStackAffinityGroup{}: {
-			UseCache: true,
+			UseCache:                            true,
+			UseStatusForStorageVersionMigration: true,
 		},
 		&infrav1.CloudStackMachineStateChecker{}: {
-			UseCache: true,
+			UseCache:                            true,
+			UseStatusForStorageVersionMigration: true,
 		},
 	}
 	crdMigratorSkipPhases := []crdmigrator.Phase{}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Improve CRD migration by using the status for storage version migration where available.

Ref: https://github.com/kubernetes-sigs/cluster-api/pull/11991


*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->